### PR TITLE
docs: replace missing phone setup link with live docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ OCA seamlessly installs the **OpenClaw** AI ecosystem directly onto your device 
 
 Configure Developer Options, Stay Awake, and battery optimization to prevent Android from killing Termux.
 
-👉 **[Read Phone Setup Guide](docs/phone-setup.mdx)** for step-by-step instructions.
+👉 **[Read Phone Setup Guide](https://openclawonandroid.mintlify.app/docs/introduction)** for step-by-step instructions.
 
 #### Step 2: Install Termux 📱
 


### PR DESCRIPTION
### Motivation
- Ensure the README Quick Start link points to a reachable hosted doc instead of a missing local file to avoid user confusion.

### Description
- Updated `README.md` Quick Start section by replacing `docs/phone-setup.mdx` with `https://openclawonandroid.mintlify.app/docs/introduction`.

### Testing
- Confirmed the local file was absent using `test -f docs/phone-setup.mdx; echo $?` and validated the README change with `git diff` and `nl -ba README.md | sed -n '45,70p'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ac3a26d0832fb06a043d36781117)