### PR TITLE
Add optional Homebrew and Go toolchain install (installer + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ openclaw onboard
 
 Follow the on-screen instructions.
 
+> **Recommended**: Say **Yes** to the new **Homebrew (Linuxbrew)** and **Go toolchain** prompts if you plan to install extra OpenClaw skills, helper CLIs, or additional Linux userland tools.
+
 #### Step 6: Start Gateway
 
 ```bash

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -91,7 +91,25 @@ Also writes the **DNS fix** (`$PREFIX/glibc/etc/resolv.conf`) to prevent `EAI_AG
 
 ## Step 7 — Optional Tools Install
 
-Installs selected tools: Termux packages via `pkg`, AI CLIs via `npm install -g`.
+Installs selected tools: Termux packages via `pkg`, AI CLIs via `npm install -g`, and optionally **Homebrew (Linuxbrew)** plus the **Go toolchain** for extra OpenClaw skill/helper workflows.
+
+### Homebrew (`scripts/install-homebrew.sh`)
+
+If selected, OCA runs the official Homebrew installer into `~/.linuxbrew` and appends:
+
+```bash
+eval "$($HOME/.linuxbrew/bin/brew shellenv)"
+```
+
+to `~/.bashrc`.
+
+<Warning>
+  Homebrew on Android is still **experimental**. The OCA glibc runtime makes many Linux tools usable, but some formulae may still need manual tweaks.
+</Warning>
+
+### Go (`scripts/install-go.sh`)
+
+If selected, OCA installs the Termux `golang` package so `go install ...` workflows are ready for OpenClaw skills, helper CLIs, and small utilities.
 
 ---
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -36,6 +36,8 @@ The installer walks you through **8 steps** with yes/no prompts:
 | Install dufs (file server)? | Optional |
 | Install android-tools (adb)? | ✅ Yes — useful for debugging |
 | Install code-server (browser IDE)? | Optional |
+| Install Homebrew (Linuxbrew)? | ✅ Recommended if you want extra glibc/Linux packages |
+| Install Go toolchain? | ✅ Recommended for `go install`-based skills and helpers |
 | Install OpenCode (AI assistant)? | Optional |
 | Install Claude Code CLI? | Your choice |
 | Install Gemini CLI? | Your choice |
@@ -58,6 +60,12 @@ Expected output:
 [OK] OpenClaw gateway: running
 [OK] Node.js v24.x.x (glibc, grun wrapper)
 [OK] platform: linux
+```
+
+If you enabled Homebrew and Go during setup, reload your shell and verify them:
+
+```bash
+source ~/.bashrc && brew --version && go version
 ```
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,8 @@ INSTALL_TTYD=false
 INSTALL_DUFS=false
 INSTALL_ANDROID_TOOLS=false
 INSTALL_CODE_SERVER=false
+INSTALL_HOMEBREW=false
+INSTALL_GO=false
 INSTALL_OPENCODE=false
 INSTALL_CLAUDE_CODE=false
 INSTALL_GEMINI_CLI=false
@@ -53,6 +55,8 @@ if ask_yn_labeled "Install ttyd (web terminal)?" "optional"; then INSTALL_TTYD=t
 if ask_yn_labeled "Install dufs (file server)?" "optional"; then INSTALL_DUFS=true; fi
 if ask_yn_labeled "Install android-tools (adb)?" "optional but highly recommended"; then INSTALL_ANDROID_TOOLS=true; fi
 if ask_yn_labeled "Install code-server (browser IDE)?" "optional"; then INSTALL_CODE_SERVER=true; fi
+if ask_yn_labeled "Install Homebrew (Linuxbrew, experimental)?" "recommended if you need extra glibc packages"; then INSTALL_HOMEBREW=true; fi
+if ask_yn_labeled "Install Go toolchain?" "recommended for skills and go install workflows"; then INSTALL_GO=true; fi
 if ask_yn_labeled "Install OpenCode (AI coding assistant)?" "optional"; then INSTALL_OPENCODE=true; fi
 if ask_yn_labeled "Install Claude Code CLI?" "optional"; then INSTALL_CLAUDE_CODE=true; fi
 if ask_yn_labeled "Install Gemini CLI?" "optional"; then INSTALL_GEMINI_CLI=true; fi
@@ -120,6 +124,12 @@ step 7 "Install Optional Tools & Features (L3)"
 
 # ── code-server ──
 [ "$INSTALL_CODE_SERVER" = true ] && mkdir -p "$PROJECT_DIR/patches" && cp "$SCRIPT_DIR/patches/argon2-stub.js" "$PROJECT_DIR/patches/argon2-stub.js" && bash "$SCRIPT_DIR/scripts/install-code-server.sh" install || true
+
+# ── Homebrew (Linuxbrew) ──
+[ "$INSTALL_HOMEBREW" = true ] && bash "$SCRIPT_DIR/scripts/install-homebrew.sh" || true
+
+# ── Go toolchain ──
+[ "$INSTALL_GO" = true ] && bash "$SCRIPT_DIR/scripts/install-go.sh" || true
 
 # ── OpenCode ──
 [ "$INSTALL_OPENCODE" = true ] && bash "$SCRIPT_DIR/scripts/install-opencode.sh" install || true

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# install-go.sh - Install Go toolchain for OpenClaw skills and go install workflows
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo "=== OCA — Installing Go Toolchain ==="
+echo ""
+
+if command -v go >/dev/null 2>&1; then
+    echo -e "${GREEN}[SKIP]${NC} Go already installed: $(go version)"
+    exit 0
+fi
+
+echo -e "${CYAN}[INFO]${NC} Installing golang from Termux packages"
+pkg install -y golang
+
+if command -v go >/dev/null 2>&1; then
+    echo -e "${GREEN}[OK]${NC}   $(go version)"
+    echo -e "${YELLOW}[INFO]${NC} You can now use 'go install ...' for OpenClaw skills and helper tools."
+else
+    echo -e "${YELLOW}[INFO]${NC} golang package installed, but 'go' is not in PATH yet. Restart Termux or source ~/.bashrc."
+fi

--- a/scripts/install-homebrew.sh
+++ b/scripts/install-homebrew.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# install-homebrew.sh - Install Homebrew (Linuxbrew) inside the glibc-enabled OCA environment
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+BREW_PREFIX="${HOME}/.linuxbrew"
+BREW_BIN="${BREW_PREFIX}/bin/brew"
+SHELLENV_LINE='eval "$($HOME/.linuxbrew/bin/brew shellenv)"'
+
+echo "=== OCA — Installing Homebrew (experimental) ==="
+echo ""
+
+if [ "$(uname -m)" != "aarch64" ]; then
+    echo -e "${RED}[FAIL]${NC} Homebrew support is currently documented for aarch64 only"
+    exit 1
+fi
+
+if [ ! -x "$PREFIX/bin/grun" ]; then
+    echo -e "${RED}[FAIL]${NC} grun not found — install glibc runtime first"
+    exit 1
+fi
+
+if [ -x "$BREW_BIN" ]; then
+    echo -e "${GREEN}[SKIP]${NC} Homebrew already installed at $BREW_BIN"
+else
+    echo -e "${CYAN}[INFO]${NC} Installing Homebrew into ${BREW_PREFIX}"
+    export NONINTERACTIVE=1
+    export CI=1
+    export HOME="$HOME"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+mkdir -p "$BREW_PREFIX/bin"
+
+if ! grep -Fq "$SHELLENV_LINE" "$HOME/.bashrc" 2>/dev/null; then
+    {
+        echo ""
+        echo "# Homebrew (managed by OCA)"
+        echo "$SHELLENV_LINE"
+    } >> "$HOME/.bashrc"
+    echo -e "${GREEN}[OK]${NC}   Added Homebrew shellenv to ~/.bashrc"
+fi
+
+eval "$("$BREW_BIN" shellenv)"
+
+echo -e "${YELLOW}[INFO]${NC} Homebrew depends on the glibc-enabled OCA environment; some formulae may still require manual tweaks on Android."
+echo -e "${GREEN}[OK]${NC}   Homebrew ready: $("$BREW_BIN" --version | head -n 1)"


### PR DESCRIPTION
### Motivation

- Provide optional support for installing Homebrew (Linuxbrew) and the Go toolchain so users can install extra glibc-aware packages and `go install`-based OpenClaw skills within the OCA environment.
- Make it explicit in the UI and docs that these are optional/experimental features that integrate with the existing glibc-enabled runtime.

### Description

- Added interactive options to the installer (`install.sh`) for `Install Homebrew (Linuxbrew)` and `Install Go toolchain` and wired them into the optional tools step and step 7 execution flow.
- Added `scripts/install-homebrew.sh` which runs the official Homebrew installer into `~/.linuxbrew`, appends `eval "$($HOME/.linuxbrew/bin/brew shellenv)"` to `~/.bashrc`, and validates the glibc runtime and architecture before installing.
- Added `scripts/install-go.sh` which installs the Termux `golang` package and reports status, skipping if `go` is already present.
- Updated user-facing documentation (`README.md`, `docs/installation.mdx`, and `docs/quickstart.mdx`) to document the new options, installation behavior, and verification steps.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c094c1777c832f875d2a903b747074)