### PR TITLE
fix(go): add --library-path to glibc wrapper and bump to Go 1.24.3

### DIFF
--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -8,7 +8,7 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-GO_VERSION="1.23.4"
+GO_VERSION="1.24.3"
 OPENCLAW_DIR="$HOME/.oca"
 GO_DIR="$OPENCLAW_DIR/go"
 
@@ -99,7 +99,7 @@ for cmd in go gofmt; do
 #!/$PREFIX/bin/bash
 [ -n "\$LD_PRELOAD" ] && export _OA_ORIG_LD_PRELOAD="\$LD_PRELOAD"
 unset LD_PRELOAD
-exec "$GLIBC_LDSO" "\$(dirname "\$0")/${cmd}.real" "\$@"
+exec "$GLIBC_LDSO" --library-path "$PREFIX/glibc/lib" "\$(dirname "\$0")/${cmd}.real" "\$@"
 WRAPPER
     chmod +x "$GO_DIR/bin/$cmd"
     
@@ -118,5 +118,13 @@ if "$GO_DIR/bin/go" version >/dev/null 2>&1; then
     echo -e "${CYAN}[INFO]${NC} You can now use 'go install' natively for Linux skills!"
 else
     echo -e "${RED}[FAIL]${NC} Go verification failed — wrapper script or glibc linker setup may be broken."
+    echo "--- Wrapper script content ---"
+    cat "$GO_DIR/bin/go"
+    echo "--- go.real exists? ---"
+    if [ -f "$GO_DIR/bin/go.real" ]; then echo "go.real exists"; else echo "go.real missing"; fi
+    echo "--- ldd on go.real ---"
+    ldd "$GO_DIR/bin/go.real" || true
+    echo "--- direct ld run ---"
+    "$GLIBC_LDSO" --library-path "$PREFIX/glibc/lib" "$GO_DIR/bin/go.real" version || true
     exit 1
 fi


### PR DESCRIPTION
## Summary

Fixes #12, #13, #14 — Go verification failure during OCA install.

- **Root cause:** `install-go.sh` generated wrapper scripts that invoked `ld-linux-aarch64.so.1` without the `--library-path` flag. The glibc dynamic linker had no way to locate shared libraries at `$PREFIX/glibc/lib`, so the Go binary failed to start immediately after installation.
- **Go version bump:** 1.23.4 → 1.24.3 (latest stable)
- **Diagnostics added:** Verification failure now prints wrapper content, checks for `go.real`, runs `ldd`, and attempts a direct `ld.so` invocation — so users can self-diagnose instead of seeing a blank error.

## Changes

| File | What changed |
|------|-------------|
| `scripts/install-go.sh` | Added `--library-path "$PREFIX/glibc/lib"` to wrapper `exec`; bumped Go to 1.24.3; added debug output on verify failure |

## Test plan

- [ ] Clean Termux install on aarch64 — run `openclaw onboard` through RTX3 tier
- [ ] Verify `go version` succeeds after install
- [ ] Verify `gofmt --version` succeeds
- [ ] Confirm upgrade path: existing 1.23.4 install upgrades cleanly to 1.24.3

## Agent Swarm Credit

> Orchestrated by Jarvis (RTX) · Copilot CLI (fix) · Gemini CLI (docs) · gh CLI (issue triage)

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to v1.24.3
  * Enhanced installation script with improved verification and debugging capabilities during setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PsProsen-Dev/OpenClaw-On-Android/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->