### PR TITLE
Fix Termux curl bootstrap recovery and safe download flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,27 @@ Configure Developer Options, Stay Awake, and battery optimization to prevent And
 Open Termux and run:
 
 ```bash
-pkg update -y && pkg install -y curl
+pkg update -y && pkg upgrade -y
+pkg install -y curl openssl libngtcp2 ca-certificates
 ```
+
+If Termux prints an error like `CANNOT LINK EXECUTABLE "curl"` or mentions
+`SSL_set_quic_tls_transport_params`, your Termux SSL/HTTP packages are out of
+sync. Re-run the two commands above, then start a fresh Termux session or run
+`hash -r` before installing OCA.
 
 #### Step 4: Install OCA 🚀
 
 ```bash
-curl -sL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh | bash && source ~/.bashrc
+BOOTSTRAP="${TMPDIR:-/tmp}/oca-bootstrap.sh"
+curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o "$BOOTSTRAP" \
+  && bash "$BOOTSTRAP" \
+  && [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
 ```
+
+This downloads the bootstrap script first instead of piping directly into
+`bash`, so a broken `curl` cannot accidentally run an empty installer and then
+try to source a missing `~/.bashrc`.
 
 Takes 3-10 minutes depending on network and device.
 
@@ -459,7 +472,9 @@ Using _Jarvis (RTX⚡)_
 ### 🚀 Ready to transform your Android phone?
 
 ```bash
-curl -sL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh | bash
+BOOTSTRAP="${TMPDIR:-/tmp}/oca-bootstrap.sh"
+curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o "$BOOTSTRAP" \
+  && bash "$BOOTSTRAP"
 ```
 
 **Your phone is now an AI server.** ⚡

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # bootstrap.sh - Download and run OpenClaw on Android installer
-# Usage: curl -sL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/main/bootstrap.sh | bash
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o /tmp/oca-bootstrap.sh \
+#     && bash /tmp/oca-bootstrap.sh
 set -euo pipefail
 
 REPO_TARBALL="https://github.com/PsProsen-Dev/OpenClaw-On-Android/archive/refs/heads/master.tar.gz"
@@ -8,20 +10,40 @@ INSTALL_DIR="$HOME/.oca/installer"
 
 RED='\033[0;31m'
 BOLD='\033[1m'
+YELLOW='\033[1;33m'
 NC='\033[0m'
+
+print_curl_repair_hint() {
+    echo -e "${YELLOW}[FIX]${NC} Termux curl/OpenSSL packages look out of sync. Run:"
+    echo ""
+    echo "  pkg update -y && pkg upgrade -y"
+    echo "  pkg install -y curl openssl libngtcp2 ca-certificates"
+    echo "  hash -r"
+    echo ""
+    echo "Then re-run the OCA install command."
+}
 
 echo ""
 echo -e "${BOLD}OpenClaw on Android - Bootstrap${NC}"
 echo ""
 
-if ! command -v curl &>/dev/null; then
-    echo -e "${RED}[FAIL]${NC} curl not found. Install it with: pkg install curl"
+if command -v curl &>/dev/null; then
+    if ! curl --version &>/dev/null; then
+        echo -e "${RED}[FAIL]${NC} curl is installed but cannot start."
+        print_curl_repair_hint
+        exit 1
+    fi
+    DOWNLOADER=(curl -sfL "$REPO_TARBALL")
+elif command -v wget &>/dev/null; then
+    DOWNLOADER=(wget -qO- "$REPO_TARBALL")
+else
+    echo -e "${RED}[FAIL]${NC} curl/wget not found. Install one with: pkg install curl"
     exit 1
 fi
 
 echo "Downloading installer..."
 mkdir -p "$INSTALL_DIR"
-curl -sfL "$REPO_TARBALL" | tar xz -C "$INSTALL_DIR" --strip-components=1
+"${DOWNLOADER[@]}" | tar xz -C "$INSTALL_DIR" --strip-components=1
 
 bash "$INSTALL_DIR/install.sh"
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -141,5 +141,8 @@ bash ~/.oca/scripts/install-nodejs.sh
 bash ~/.oca/platforms/openclaw/install.sh
 
 # Full reinstall
-oca --uninstall && curl -sL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh | bash
+oca --uninstall
+BOOTSTRAP="${TMPDIR:-/tmp}/oca-bootstrap.sh"
+curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o "$BOOTSTRAP" \
+  && bash "$BOOTSTRAP"
 ```

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -33,11 +33,30 @@ OCA works with multiple free AI providers — no credit card needed to get start
 
 ## Step 1 — Run the bootstrap
 
-Open Termux and paste this single command:
+Open Termux and first refresh the packages that `curl` links against:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh | bash && source ~/.bashrc
+pkg update -y && pkg upgrade -y
+pkg install -y curl openssl libngtcp2 ca-certificates
 ```
+
+If you see `CANNOT LINK EXECUTABLE "curl"` or
+`SSL_set_quic_tls_transport_params`, the Termux `curl`/OpenSSL packages are
+out of sync. Run the two commands above, then run `hash -r` or reopen Termux.
+
+Then paste this install command:
+
+```bash
+BOOTSTRAP="${TMPDIR:-/tmp}/oca-bootstrap.sh"
+curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o "$BOOTSTRAP" \
+  && bash "$BOOTSTRAP" \
+  && [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
+```
+
+This avoids the classic `curl | bash && source ~/.bashrc` trap: if `curl`
+fails before downloading anything, `bash` can otherwise receive empty input and
+return success, which makes the shell try to source a `.bashrc` that the
+installer never created.
 
 ---
 

--- a/docs/support/common-issues.mdx
+++ b/docs/support/common-issues.mdx
@@ -20,7 +20,34 @@ npm clean-cache --force
 npm install -g openclaw@latest
 ```
 
-## 2. Sharp Compilation Errors
+## 2. `curl` fails with `SSL_set_quic_tls_transport_params`
+
+**Error:** Before the installer starts, Termux prints something like:
+
+```text
+CANNOT LINK EXECUTABLE "curl": cannot locate symbol "SSL_set_quic_tls_transport_params" referenced by ".../libngtcp2_crypto_ossl.so"...
+bash: .../home/.bashrc: No such file or directory
+```
+
+**Cause:** Termux upgraded only part of the HTTP/TLS stack. `curl`, `openssl`,
+and `libngtcp2` must come from a matching package set. The `.bashrc` message is
+a follow-on symptom from the old `curl | bash && source ~/.bashrc` pattern: no
+installer was downloaded, so no `.bashrc` was created.
+
+**Fix:** Repair the Termux packages and use the safe bootstrap command:
+
+```bash
+pkg update -y && pkg upgrade -y
+pkg install -y curl openssl libngtcp2 ca-certificates
+hash -r
+
+BOOTSTRAP="${TMPDIR:-/tmp}/oca-bootstrap.sh"
+curl -fsSL https://raw.githubusercontent.com/PsProsen-Dev/OpenClaw-On-Android/master/bootstrap.sh -o "$BOOTSTRAP" \
+  && bash "$BOOTSTRAP" \
+  && [ -f "$HOME/.bashrc" ] && source "$HOME/.bashrc"
+```
+
+## 3. Sharp Compilation Errors
 
 **Error:** `sharp: Installation error: Use with glibc ... is not supported`
 
@@ -33,7 +60,7 @@ export npm_config_build_from_source=true
 npm rebuild sharp
 ```
 
-## 3. "Cannot find module 'bionic-compat'"
+## 4. "Cannot find module 'bionic-compat'"
 
 **Error:** When starting `openclaw gateway`, it crashes immediately complaining about `bionic-compat.js`.
 
@@ -45,7 +72,7 @@ cd /data/data/com.termux/files/usr/lib/node_modules/openclaw/
 # Download the shims as per the manual setup guide
 ```
 
-## 4. Network/DNS Errors (EAI_AGAIN)
+## 5. Network/DNS Errors (EAI_AGAIN)
 
 **Error:** The agent fails to connect to the LLM provider with `getaddrinfo EAI_AGAIN api.openai.com`.
 
@@ -53,7 +80,7 @@ cd /data/data/com.termux/files/usr/lib/node_modules/openclaw/
 **Fix:**
 Ensure `proxy.js` is installed and correctly overriding the DNS resolution to use Google/Cloudflare DNS directly (8.8.8.8 / 1.1.1.1). Our bootstrap script applies this automatically.
 
-## 5. Gateway Keeps Shutting Down
+## 6. Gateway Keeps Shutting Down
 
 **Error:** You lock your phone, and a few minutes later, the bot stops responding.
 


### PR DESCRIPTION
### Motivation
- Users can see Termux errors like `CANNOT LINK EXECUTABLE "curl"` or `SSL_set_quic_tls_transport_params` when `curl`/OpenSSL/libngtcp2 packages are out of sync, and the old `curl | bash && source ~/.bashrc` pattern can cause a missing `.bashrc` symptom if the downloader fails.
- Make the bootstrap safer and more actionable by detecting broken `curl`, providing a recovery hint, and avoiding piping untrusted/empty input directly into `bash`.

### Description
- Add a `curl` health check and repair hint via a new `print_curl_repair_hint()` helper in `bootstrap.sh`, and prefer a download-to-file flow with a `DOWNLOADER` array that supports `curl` and a `wget` fallback while feeding the tarball into `tar` (`bootstrap.sh`).
- Replace the direct `curl | tar` call with the resilient `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20456e3b748328bbab10c21785fe57)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android/Termux setup instructions with expanded step-by-step guidance and dependency installation details.
  * Added troubleshooting section for Termux SSL/TLS errors with recommended recovery steps.
  * Revised bootstrap installation procedures with safer file-based execution method.

* **Bug Fixes**
  * Enhanced bootstrap script to support multiple downloaders and improved error handling for networking issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->